### PR TITLE
Optimize common API usage for Call

### DIFF
--- a/lua/includes/modules/hook.lua
+++ b/lua/includes/modules/hook.lua
@@ -363,7 +363,7 @@ function Call(event_name, gm, ...)
 	do -- post hooks
 		local post_hooks = lists[3]
 		local n_ph = post_hooks[0 --[[length]]]
-		if n_ph ~= 0 and not returned_values then
+		if n_ph ~= 0 then
 			returned_values[1] = hook_name
 			returned_values[2] = a
 			returned_values[3] = b


### PR DESCRIPTION
Since most hooks will probably not opt to use the priority feature, I thought it would be best to reuse the returned_values table. This does change the API a little though as it imposes some limitations on the arguments table passed to the post hooks. If users are (hopefully) using the table as read-only there's no issue.

It's up to you what should be supported behavior. If the potentially API breaking change is unwanted I could edit this to focus on conservative table initialization.